### PR TITLE
Added @WithUser annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,16 +93,15 @@
             <artifactId>commons-io</artifactId>
             <version>${commons-io.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+        </dependency>
+
         <!-- TEST dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-test</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/WithUser.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/WithUser.java
@@ -12,7 +12,10 @@ import java.lang.annotation.*;
 public @interface WithUser {
 
     /**
-     * Specifies the username.
+     * SPeL expression resulting in a RegisteredUser to be used as logged in user.
+     *
+     * For example: @userBuilder.defaultUser()
+     *
      * @return
      */
     String value();

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/WithUser.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/WithUser.java
@@ -1,0 +1,20 @@
+package nl._42.restsecure.autoconfigure.authentication;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.*;
+
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@WithSecurityContext(factory = WithUserSecurityContextFactory.class)
+public @interface WithUser {
+
+    /**
+     * Specifies the username.
+     * @return
+     */
+    String value();
+
+}

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/WithUserSecurityContextFactory.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/WithUserSecurityContextFactory.java
@@ -1,0 +1,79 @@
+package nl._42.restsecure.autoconfigure.authentication;
+
+import nl._42.restsecure.autoconfigure.authentication.RegisteredUser;
+import nl._42.restsecure.autoconfigure.authentication.UserDetailsAdapter;
+import nl._42.restsecure.autoconfigure.authentication.WithUser;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.context.expression.BeanFactoryResolver;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+public final class WithUserSecurityContextFactory implements
+        WithSecurityContextFactory<WithUser>, BeanFactoryAware {
+
+    private BeanFactory beanFactory;
+
+    /**
+     * Reads the expression resulting in a {@link nl._42.restsecure.autoconfigure.authentication.RegisteredUser}
+     * and sets the user as authenticated in the SecurityContext
+     *
+     * @param withUser withUser annotation
+     * @return SecurityContext to set
+     */
+    public SecurityContext createSecurityContext(WithUser withUser) {
+        String userExpression = withUser.value();
+        RegisteredUser registeredUser = evaluateExpression(userExpression);
+
+        List<GrantedAuthority> authorityList = buildAuthorities(registeredUser);
+
+        Authentication token = new UsernamePasswordAuthenticationToken(
+                new UserDetailsAdapter<RegisteredUser>(registeredUser),
+                null,
+                authorityList
+        );
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        securityContext.setAuthentication(token);
+        return securityContext;
+    }
+
+    private List<GrantedAuthority> buildAuthorities(RegisteredUser registeredUser) {
+        return registeredUser.getAuthorities()
+                .stream()
+                .map(a -> new SimpleGrantedAuthority(a))
+                .collect(toList());
+    }
+
+    /**
+     *
+     * @param userExpression expression to evaluate to a RegisteredUser
+     * @return RegisteredUser instance
+     */
+    private RegisteredUser evaluateExpression(String userExpression) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        context.setBeanResolver(new BeanFactoryResolver(this.beanFactory));
+
+        Expression expression = parser.parseExpression(userExpression);
+        return expression.getValue(context, RegisteredUser.class);
+    }
+
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+        this.beanFactory = beanFactory;
+    }
+}

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/WithUserSecurityContextFactory.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/WithUserSecurityContextFactory.java
@@ -54,7 +54,7 @@ public final class WithUserSecurityContextFactory implements
     private List<GrantedAuthority> buildAuthorities(RegisteredUser registeredUser) {
         return registeredUser.getAuthorities()
                 .stream()
-                .map(a -> new SimpleGrantedAuthority(a))
+                .map(authority -> new SimpleGrantedAuthority(authority))
                 .collect(toList());
     }
 

--- a/src/test/java/nl/_42/restsecure/autoconfigure/AbstractApplicationContextTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/AbstractApplicationContextTest.java
@@ -14,14 +14,17 @@ import nl._42.restsecure.autoconfigure.authentication.RegisteredUser;
 import nl._42.restsecure.autoconfigure.authentication.UserDetailsAdapter;
 
 import org.junit.After;
+import org.junit.runner.RunWith;
 import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.boot.test.util.ApplicationContextTestUtils;
 import org.springframework.mock.web.MockServletContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 
+@RunWith(SpringJUnit4ClassRunner.class)
 public abstract class AbstractApplicationContextTest {
 
     protected AnnotationConfigWebApplicationContext context;
@@ -32,19 +35,18 @@ public abstract class AbstractApplicationContextTest {
             this.context.close();
         }
     }
-    
+
     protected MockMvc getWebClient(Class<?>... appConfig) {
         loadApplicationContext(appConfig);
         return webAppContextSetup(context)
             .apply(springSecurity())
             .defaultRequest(get("/")
                 .contentType(APPLICATION_JSON)
-                .with(csrf())
-                .with(user(new UserDetailsAdapter<RegisteredUser>(user().build()))))
+                .with(csrf()))
             .alwaysDo(log())
             .build();
     }
-   
+
     protected void loadApplicationContext() {
         this.context = load(new AnnotationConfigWebApplicationContext());
     }

--- a/src/test/java/nl/_42/restsecure/autoconfigure/AbstractApplicationContextTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/AbstractApplicationContextTest.java
@@ -1,24 +1,17 @@
 package nl._42.restsecure.autoconfigure;
 
-import static nl._42.restsecure.autoconfigure.test.AbstractUserDetailsServiceConfig.RegisteredUserBuilder.user;
-
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
-
-import nl._42.restsecure.autoconfigure.authentication.RegisteredUser;
-import nl._42.restsecure.autoconfigure.authentication.UserDetailsAdapter;
 
 import org.junit.After;
 import org.junit.runner.RunWith;
 import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
-import org.springframework.boot.test.util.ApplicationContextTestUtils;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/AuthenticationControllerTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/AuthenticationControllerTest.java
@@ -19,7 +19,9 @@ import nl._42.restsecure.autoconfigure.test.InMemoryCrowdConfig;
 import nl._42.restsecure.autoconfigure.test.MockedCrowdAuthenticationProviderConfig;
 import nl._42.restsecure.autoconfigure.test.NoopPasswordEncoderConfig;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.springframework.security.test.context.support.WithMockUser;
 
 public class AuthenticationControllerTest extends AbstractApplicationContextTest {
 
@@ -32,6 +34,7 @@ public class AuthenticationControllerTest extends AbstractApplicationContextTest
     }
 
     @Test
+    @WithUser("T(nl._42.restsecure.autoconfigure.test.AbstractUserDetailsServiceConfig.RegisteredUserBuilder).user().build()")
     public void currentUser_shouldSucceed_whenLoggedIn() throws Exception {
         getWebClient(ActiveUserConfig.class)
             .perform(get("/authentication/current"))
@@ -41,6 +44,7 @@ public class AuthenticationControllerTest extends AbstractApplicationContextTest
     }
 
     @Test
+    @WithUser("T(nl._42.restsecure.autoconfigure.test.AbstractUserDetailsServiceConfig.RegisteredUserBuilder).user().build()")
     public void currentUser_shouldSucceed_whenNotLoggedIn_andCustomWebSecurity() throws Exception {
         getWebClient(ActiveUserConfig.class, CustomWebSecurityAndHttpSecurityConfig.class)
             .perform(get("/authentication/current"))
@@ -50,6 +54,7 @@ public class AuthenticationControllerTest extends AbstractApplicationContextTest
     }
 
     @Test
+    @WithUser("T(nl._42.restsecure.autoconfigure.test.AbstractUserDetailsServiceConfig.RegisteredUserBuilder).user().build()")
     public void currentUser_shouldReturnCustomAuthenticationResult_withCustomAuthenticationResultProvider() throws Exception {
         getWebClient(AuthenticationResultProviderConfig.class)
             .perform(get("/authentication/current"))

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/AuthenticationControllerTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/AuthenticationControllerTest.java
@@ -19,9 +19,7 @@ import nl._42.restsecure.autoconfigure.test.InMemoryCrowdConfig;
 import nl._42.restsecure.autoconfigure.test.MockedCrowdAuthenticationProviderConfig;
 import nl._42.restsecure.autoconfigure.test.NoopPasswordEncoderConfig;
 
-import org.junit.Before;
 import org.junit.Test;
-import org.springframework.security.test.context.support.WithMockUser;
 
 public class AuthenticationControllerTest extends AbstractApplicationContextTest {
 

--- a/src/test/java/nl/_42/restsecure/autoconfigure/errorhandling/AccessDeniedHandlerTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/errorhandling/AccessDeniedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppC
 import javax.servlet.ServletContext;
 
 import nl._42.restsecure.autoconfigure.AbstractApplicationContextTest;
+import nl._42.restsecure.autoconfigure.authentication.WithUser;
 import nl._42.restsecure.autoconfigure.test.ActiveUserConfig;
 import nl._42.restsecure.autoconfigure.test.RestrictedEndpointsConfig;
 
@@ -23,6 +24,7 @@ import org.springframework.test.web.servlet.RequestBuilder;
 public class AccessDeniedHandlerTest extends AbstractApplicationContextTest {
 
     @Test
+    @WithUser("T(nl._42.restsecure.autoconfigure.test.AbstractUserDetailsServiceConfig.RegisteredUserBuilder).user().build()")
     public void forbiddenEndpoint_shouldFail_whenAdmin() throws Exception {
         getWebClient(RestrictedEndpointsConfig.class)
             .perform(get("/test/forbidden"))

--- a/src/test/java/nl/_42/restsecure/autoconfigure/errorhandling/WebMvcErrorHandlingTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/errorhandling/WebMvcErrorHandlingTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import nl._42.restsecure.autoconfigure.AbstractApplicationContextTest;
+import nl._42.restsecure.autoconfigure.authentication.WithUser;
 import nl._42.restsecure.autoconfigure.test.RestrictedEndpointsConfig;
 
 import org.junit.Test;
@@ -13,6 +14,7 @@ import org.junit.Test;
 public class WebMvcErrorHandlingTest extends AbstractApplicationContextTest {
 
     @Test
+    @WithUser("T(nl._42.restsecure.autoconfigure.test.AbstractUserDetailsServiceConfig.RegisteredUserBuilder).user().build()")
     public void forbiddenEndpoint_shouldFail_whenAdmin() throws Exception {
         getWebClient(RestrictedEndpointsConfig.class)
             .perform(get("/test/preauthorized"))


### PR DESCRIPTION
Can be put before any test, setting an actual RegisteredUser object on the SecurityContext instead of the mocked @WithMockUser.
@WithMockUser does not play nicely with @CurrentUser. Because of this, we need @WithUser.

 - Added @WithUser based on @WithMockUser
 - Added Spring's unit test runner to AbstractApplicationContextTest so that @WithUser is loaded into JUnit
 - Modified AuthenticationControllertest, AccessDeniedHandlerTest and WebMvcErrorHandlingTest to use @WithUser

TODO:
- Move new annotations to a new project: rest-ecure-spring-boot-starter-test ?