### PR TITLE
Fixed authentication adapter to work with isAuthenticated() expressions

### DIFF
--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/AuthenticationAdapter.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/AuthenticationAdapter.java
@@ -1,28 +1,23 @@
 package nl._42.restsecure.autoconfigure.authentication;
 
-import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
-public class AuthenticationAdapter extends AbstractAuthenticationToken {
+/**
+ * Authentication implementation that is based on a user object. The
+ * principal is a user details adapter, containing the original user.
+ */
+public class AuthenticationAdapter extends UsernamePasswordAuthenticationToken {
 
-  private final UserDetailsAdapter<RegisteredUser> user;
-
+  /**
+   * Create a new authentication based on a user.
+   * @param user the registered user
+   */
   public AuthenticationAdapter(RegisteredUser user) {
-    this(new UserDetailsAdapter<>(user));
+    this(new UserDetailsAdapter(user));
   }
 
-  private AuthenticationAdapter(UserDetailsAdapter<RegisteredUser> user) {
-    super(user.getAuthorities());
-    this.user = user;
-  }
-
-  @Override
-  public Object getCredentials() {
-    return "";
-  }
-
-  @Override
-  public Object getPrincipal() {
-    return user;
+  private AuthenticationAdapter(UserDetailsAdapter details) {
+    super(details,"", details.getAuthorities());
   }
 
 }

--- a/src/test/java/nl/_42/restsecure/autoconfigure/AbstractApplicationContextTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/AbstractApplicationContextTest.java
@@ -40,10 +40,6 @@ public abstract class AbstractApplicationContextTest {
             .alwaysDo(log())
             .build();
     }
-   
-    protected void loadApplicationContext() {
-        this.context = load(new AnnotationConfigWebApplicationContext());
-    }
 
     protected void loadApplicationContext(Class<?>... config) {
         AnnotationConfigWebApplicationContext appContext = new AnnotationConfigWebApplicationContext();
@@ -61,4 +57,5 @@ public abstract class AbstractApplicationContextTest {
         applicationContext.refresh();
         return applicationContext;
     }
+
 }

--- a/src/test/java/nl/_42/restsecure/autoconfigure/MethodSecurityTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/MethodSecurityTest.java
@@ -1,0 +1,82 @@
+package nl._42.restsecure.autoconfigure;
+
+import nl._42.restsecure.autoconfigure.authentication.AuthenticationAdapter;
+import nl._42.restsecure.autoconfigure.authentication.RegisteredUser;
+import nl._42.restsecure.autoconfigure.authentication.User;
+import nl._42.restsecure.autoconfigure.test.MethodSecurityConfig;
+import nl._42.restsecure.autoconfigure.test.SecuredService;
+import org.junit.Test;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertTrue;
+
+public class MethodSecurityTest extends AbstractApplicationContextTest {
+
+  @Test
+  public void everybody_shouldSucceed() {
+    SecuredService securedService = getSecuredService();
+    assertTrue(securedService.everybody());
+  }
+
+  @Test
+  public void authenticated_shouldSucceed_whenLoggedIn() {
+    SecuredService securedService = getSecuredService();
+
+    User user = new User("user", "ROLE_user");
+    assertTrue(runAs(user, securedService::authenticated));
+  }
+
+  @Test(expected = AuthenticationCredentialsNotFoundException.class)
+  public void authenticated_shouldFail_whenAnonymous() {
+    SecuredService securedService = getSecuredService();
+    assertTrue(securedService.authenticated());
+  }
+
+  @Test
+  public void admin_shouldSucceed_whenAdmin() {
+    SecuredService securedService = getSecuredService();
+
+    User admin = new User("admin", "ROLE_admin");
+    assertTrue(runAs(admin, securedService::admin));
+  }
+
+  @Test(expected = AccessDeniedException.class)
+  public void admin_shouldFail_whenUser() {
+    SecuredService securedService = getSecuredService();
+
+    User user = new User("user", "ROLE_user");
+    assertTrue(runAs(user, securedService::admin));
+  }
+
+  @Test(expected = AuthenticationCredentialsNotFoundException.class)
+  public void admin_shouldFail_whenAnonymous() {
+    SecuredService securedService = getSecuredService();
+    assertTrue(securedService.admin());
+  }
+
+  private <T> T runAs(RegisteredUser user, Supplier<T> supplier) {
+    SecurityContext context = SecurityContextHolder.getContext();
+    Authentication authentication = context.getAuthentication();
+
+    try {
+      context.setAuthentication(new AuthenticationAdapter(user));
+      return supplier.get();
+    } finally {
+      context.setAuthentication(authentication);
+    }
+  }
+
+  private SecuredService getSecuredService() {
+    loadApplicationContext(MethodSecurityConfig.class);
+    this.context.refresh();
+
+    return context.getBean(SecuredService.class);
+  }
+
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/InMemoryUserDetailService.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/InMemoryUserDetailService.java
@@ -1,13 +1,16 @@
 package nl._42.restsecure.autoconfigure.authentication;
 
+import nl._42.restsecure.autoconfigure.authentication.AbstractUserDetailsService;
+import nl._42.restsecure.autoconfigure.authentication.User;
+
 import java.util.HashMap;
 import java.util.Map;
 
-class InMemoryUserDetailService extends AbstractUserDetailsService<User> {
+public class InMemoryUserDetailService extends AbstractUserDetailsService<User> {
 
   private Map<String, User> users = new HashMap<>();
 
-  void register(User user) {
+  public void register(User user) {
     users.put(user.getUsername(), user);
   }
 

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/User.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/User.java
@@ -1,14 +1,16 @@
 package nl._42.restsecure.autoconfigure.authentication;
 
+import nl._42.restsecure.autoconfigure.authentication.RegisteredUser;
+
 import java.util.Collections;
 import java.util.Set;
 
-class User implements RegisteredUser {
+public class User implements RegisteredUser {
 
   private final String username;
   private final String role;
 
-  User(String username, String role) {
+  public User(String username, String role) {
     this.username = username;
     this.role = role;
   }

--- a/src/test/java/nl/_42/restsecure/autoconfigure/errorhandling/AccessDeniedHandlerTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/errorhandling/AccessDeniedHandlerTest.java
@@ -71,4 +71,5 @@ public class AccessDeniedHandlerTest extends AbstractApplicationContextTest {
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("errorCode").value(SERVER_AUTHENTICATE_ERROR));
     }
+
 }

--- a/src/test/java/nl/_42/restsecure/autoconfigure/test/MethodSecurityConfig.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/test/MethodSecurityConfig.java
@@ -1,0 +1,20 @@
+package nl._42.restsecure.autoconfigure.test;
+
+import nl._42.restsecure.autoconfigure.authentication.InMemoryUserDetailService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MethodSecurityConfig {
+
+  @Bean
+  public InMemoryUserDetailService userDetailService() {
+    return new InMemoryUserDetailService();
+  }
+
+  @Bean
+  public SecuredService securedService() {
+    return new SecuredService();
+  }
+
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/test/SecuredService.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/test/SecuredService.java
@@ -1,0 +1,21 @@
+package nl._42.restsecure.autoconfigure.test;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+public class SecuredService {
+
+  public boolean everybody() {
+    return true;
+  }
+
+  @PreAuthorize("isAuthenticated()")
+  public boolean authenticated() {
+    return true;
+  }
+
+  @PreAuthorize("hasRole('admin')")
+  public boolean admin() {
+    return true;
+  }
+
+}


### PR DESCRIPTION
Fixed problem with isAuthenticated() expressions:

```
org.springframework.security.authentication.ProviderNotFoundException: No AuthenticationProvider found for nl._42.restsecure.autoconfigure.authentication.AuthenticationAdapter
```

When using the authentication adapter