### PR TITLE
Added support for 2FA Authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,12 @@
     <description>Spring boot starter/autoconfig for Spring security</description>
     <inceptionYear>2017</inceptionYear>
     <url>http://www.42.nl</url>
-    
+
     <organization>
         <name>42 BV</name>
         <url>http://blog.42.nl/</url>
     </organization>
-    
+
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
@@ -24,14 +24,14 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-    
+
     <scm>
         <url>https://github.com/42BV/rest-secure-spring-boot-starter</url>
         <connection>scm:git:https://github.com/42BV/rest-secure-spring-boot-starter.git</connection>
         <developerConnection>scm:git:https://github.com/42BV/rest-secure-spring-boot-starter.git</developerConnection>
       <tag>HEAD</tag>
     </scm>
-    
+
     <developers>
         <developer>
             <name>Bas de Vos</name>
@@ -42,7 +42,7 @@
             <organization>42</organization>
         </developer>
     </developers>
-    
+
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
@@ -53,15 +53,25 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
-    
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <spring-boot.version>2.4.5</spring-boot.version>
+        <spring-boot.version>2.5.6</spring-boot.version>
+        <totp-spring-boot-starter.version>1.7.1</totp-spring-boot-starter.version>
+
+        <dependency-check-maven-plugin.version>6.5.0</dependency-check-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -81,6 +91,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>dev.samstevens.totp</groupId>
+            <artifactId>totp-spring-boot-starter</artifactId>
+            <version>${totp-spring-boot-starter.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -123,17 +138,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>${maven-compiler-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>${maven-surefire-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
+                    <version>${maven-release-plugin.version}</version>
                     <configuration>
                         <mavenExecutorId>forked-path</mavenExecutorId>
                         <useReleaseProfile>false</useReleaseProfile>
@@ -147,7 +162,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.6</version>
+                <version>${jacoco-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -166,7 +181,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>6.1.5</version>
+                <version>${dependency-check-maven-plugin.version}</version>
                 <configuration>
                     <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
                     <skipProvidedScope>true</skipProvidedScope>
@@ -187,7 +202,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.2.0</version>
+                        <version>${maven-javadoc-plugin.version}</version>
                         <configuration>
                             <source>${maven.compiler.source}</source>
                         </configuration>
@@ -203,7 +218,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.2.1</version>
+                        <version>${maven-source-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -216,7 +231,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>${maven-gpg-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/src/main/java/nl/_42/restsecure/autoconfigure/MfaSecurityAutoConfig.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/MfaSecurityAutoConfig.java
@@ -1,0 +1,37 @@
+package nl._42.restsecure.autoconfigure;
+
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaSetupService;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaSetupServiceImpl;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaValidationService;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaValidationServiceImpl;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Auto-configures beans for MFA validation and configuration. These beans are dependent on the beans defined in {@link dev.samstevens.totp.spring.autoconfigure.TotpAutoConfiguration}.
+ */
+@Configuration
+@ConditionalOnClass(name = "dev.samstevens.totp.spring.autoconfigure.TotpAutoConfiguration")
+@AutoConfigureAfter(name = "dev.samstevens.totp.spring.autoconfigure.TotpAutoConfiguration")
+public class MfaSecurityAutoConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(MfaValidationService.class)
+    @ConditionalOnBean(type = "dev.samstevens.totp.code.CodeVerifier")
+    public MfaValidationService mfaValidationService(dev.samstevens.totp.code.CodeVerifier codeVerifier) {
+        return new MfaValidationServiceImpl(codeVerifier);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(MfaSetupService.class)
+    @ConditionalOnBean(type = {"dev.samstevens.totp.secret.SecretGenerator", "dev.samstevens.totp.qr.QrDataFactory", "dev.samstevens.totp.qr.QrGenerator"})
+    public MfaSetupService mfaSetupService(dev.samstevens.totp.secret.SecretGenerator secretGenerator, dev.samstevens.totp.qr.QrDataFactory qrDataFactory, dev.samstevens.totp.qr.QrGenerator qrGenerator, @Value("${totp.issuer:needs-totp-issuer}") String issuer) {
+        return new MfaSetupServiceImpl(secretGenerator, qrDataFactory, qrGenerator, issuer);
+    }
+}

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/RegisteredUser.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/RegisteredUser.java
@@ -11,27 +11,39 @@ import org.springframework.security.core.Authentication;
 public interface RegisteredUser {
 
     String getUsername();
-    
+
     default String getPassword() {
         return "";
     }
-    
+
     Set<String> getAuthorities();
-    
+
     default boolean isAccountExpired() {
         return false;
     }
-    
+
     default boolean isAccountLocked() {
         return false;
     }
-    
+
     default boolean isCredentialsExpired() {
         return false;
     }
-    
+
     default boolean isEnabled() {
         return true;
+    }
+
+    default boolean isMfaConfigured() {
+        return false;
+    }
+
+    default boolean isMfaMandatory() {
+        return false;
+    }
+
+    default String getMfaSecretKey() {
+        return null;
     }
 
 }

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/UserDetailsAdapter.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/UserDetailsAdapter.java
@@ -16,9 +16,9 @@ import org.springframework.security.core.userdetails.UserDetails;
  * @param <T> the type of the custom user.
  */
 public final class UserDetailsAdapter<T extends RegisteredUser> implements UserDetails {
-    
+
     private final T user;
-    
+
     public UserDetailsAdapter(T user) {
         this.user = user;
     }
@@ -33,7 +33,7 @@ public final class UserDetailsAdapter<T extends RegisteredUser> implements UserD
     public T getUser() {
         return user;
     }
-    
+
     @Override
     public String getPassword() {
         return user.getPassword();
@@ -64,4 +64,11 @@ public final class UserDetailsAdapter<T extends RegisteredUser> implements UserD
         return user.isEnabled();
     }
 
+    public boolean isMfaConfigured() {
+        return user.isMfaConfigured();
+    }
+
+    public boolean isMfaMandatory() {
+        return user.isMfaMandatory();
+    }
 }

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaAuthenticationProvider.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaAuthenticationProvider.java
@@ -1,0 +1,63 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+import nl._42.restsecure.autoconfigure.authentication.RegisteredUser;
+import nl._42.restsecure.autoconfigure.authentication.UserDetailsAdapter;
+import nl._42.restsecure.autoconfigure.errorhandling.DefaultLoginAuthenticationExceptionHandler;
+
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.Assert;
+
+/**
+ * An {@link DaoAuthenticationProvider} that supports Multi-Factor authentication (MFA, 2FA) using Time-based One-Time-Password (TOTP).
+ */
+public class MfaAuthenticationProvider extends DaoAuthenticationProvider {
+
+    public static final String SERVER_MFA_CODE_REQUIRED_ERROR = "SERVER.MFA_CODE_REQUIRED_ERROR";
+    public static final String DETAILS_MFA_SETUP_REQUIRED = "DETAILS.MFA_SETUP_REQUIRED";
+
+    private MfaValidationService mfaValidationService;
+
+    public void setMfaValidationService(MfaValidationService mfaValidationService) {
+        this.mfaValidationService = mfaValidationService;
+    }
+
+    @Override
+    protected void doAfterPropertiesSet() {
+        super.doAfterPropertiesSet();
+        Assert.notNull(this.mfaValidationService, "A MfaValidationService must be set");
+    }
+
+    @Override
+    protected void additionalAuthenticationChecks(UserDetails userDetails, UsernamePasswordAuthenticationToken authentication) throws AuthenticationException {
+        super.additionalAuthenticationChecks(userDetails, authentication);
+
+        if (userDetails instanceof UserDetailsAdapter) {
+            UserDetailsAdapter<? extends RegisteredUser> userDetailsAdapter = (UserDetailsAdapter<?>) userDetails;
+
+            if (userDetailsAdapter.isMfaConfigured()) {
+                MfaAuthenticationToken mfaAuthenticationToken = (MfaAuthenticationToken) authentication;
+                // If no code supplied, indicate a code is needed.
+                if (mfaAuthenticationToken.getVerificationCode() == null || mfaAuthenticationToken.getVerificationCode().equals("")) {
+                    throw new InsufficientAuthenticationException(SERVER_MFA_CODE_REQUIRED_ERROR);
+                }
+                // If invalid code supplied, authentication has failed.
+                if (!mfaValidationService.verifyMfaCode(((UserDetailsAdapter<?>) userDetails).getUser().getMfaSecretKey(), mfaAuthenticationToken.getVerificationCode())) {
+                    throw new BadCredentialsException(DefaultLoginAuthenticationExceptionHandler.SERVER_LOGIN_FAILED_ERROR);
+                }
+                // If mfa is mandatory for this user, but not setup, indicate it must be setup first.
+            } else if (userDetailsAdapter.isMfaMandatory()) {
+                authentication.setDetails(DETAILS_MFA_SETUP_REQUIRED);
+            }
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return MfaAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaAuthenticationToken.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaAuthenticationToken.java
@@ -1,0 +1,20 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+/**
+ * An {@link UsernamePasswordAuthenticationToken} that also accepts a verification code (e.g. from an authenticator app).
+ */
+public class MfaAuthenticationToken extends UsernamePasswordAuthenticationToken {
+
+    private final String verificationCode;
+
+    public MfaAuthenticationToken(Object principal, Object credentials, String verificationCode) {
+        super(principal, credentials);
+        this.verificationCode = verificationCode;
+    }
+
+    public String getVerificationCode() {
+        return verificationCode;
+    }
+}

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaException.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaException.java
@@ -1,0 +1,8 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+public class MfaException extends Exception {
+
+    public MfaException(String message, Exception cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaSetupRequiredFilter.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaSetupRequiredFilter.java
@@ -1,0 +1,97 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+import static nl._42.restsecure.autoconfigure.authentication.mfa.MfaAuthenticationProvider.DETAILS_MFA_SETUP_REQUIRED;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import lombok.Getter;
+import lombok.Setter;
+import nl._42.restsecure.autoconfigure.errorhandling.GenericErrorResult;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.Assert;
+import org.springframework.web.filter.GenericFilterBean;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * A {@link GenericFilterBean} that denies requests when the user is obliged to set up MFA but hasn't done so.
+ */
+public class MfaSetupRequiredFilter extends GenericFilterBean {
+
+    private static final String SERVER_MFA_SETUP_REQUIRED_ERROR = "SERVER.MFA_SETUP_REQUIRED_ERROR";
+
+    @Getter
+    private final List<RequestMatcher> excludedRequests = new ArrayList<>();
+
+    @Getter
+    private final List<BiFunction<ServletRequest, ServletResponse, Boolean>> exclusionChecks = new ArrayList<>();
+
+    @Setter
+    private ObjectMapper objectMapper;
+
+    @Override
+    public void afterPropertiesSet() throws ServletException {
+        super.afterPropertiesSet();
+        Assert.notNull(this.objectMapper, "A ObjectMapper must be set");
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) {
+        // We only perform this filter if the authentication contains the correct details.
+        if (!DETAILS_MFA_SETUP_REQUIRED.equals(SecurityContextHolder.getContext().getAuthentication().getDetails())) {
+            continueWithFilterChain(request, response, chain);
+            return;
+        }
+
+        // Required to allow access to public endpoints or endpoints mandatory to load the MFA setup page.
+        if (excludedRequests.stream().anyMatch(r -> r.matches(((HttpServletRequest) request)))) {
+            continueWithFilterChain(request, response, chain);
+            return;
+        }
+
+        // If any other check indicates that the MFA setup should not be performed, do not send the error.
+        if (exclusionChecks.stream().anyMatch(exclusion -> exclusion.apply(request, response))) {
+            continueWithFilterChain(request, response, chain);
+            return;
+        }
+
+        sendMfaSetupRequiredError(response);
+    }
+
+    private void sendMfaSetupRequiredError(ServletResponse response) {
+        try {
+            // Return access denied status with "mfa not setup" as the reason.
+            HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+
+            httpServletResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            httpServletResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            httpServletResponse.getOutputStream()
+                    .write(objectMapper.writeValueAsString(new GenericErrorResult(SERVER_MFA_SETUP_REQUIRED_ERROR)).getBytes());
+            httpServletResponse.getOutputStream().flush();
+        } catch (IOException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    private void continueWithFilterChain(ServletRequest request, ServletResponse response, FilterChain chain) {
+        try {
+            chain.doFilter(request, response);
+        } catch (IOException | ServletException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+}
+

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaSetupService.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaSetupService.java
@@ -1,0 +1,8 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+public interface MfaSetupService {
+
+    String generateSecret();
+
+    String generateQrCode(String secret, String label) throws MfaException;
+}

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaSetupServiceImpl.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaSetupServiceImpl.java
@@ -1,0 +1,63 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+import static dev.samstevens.totp.util.Utils.getDataUriForImage;
+
+import dev.samstevens.totp.exceptions.QrGenerationException;
+import dev.samstevens.totp.qr.QrData;
+import dev.samstevens.totp.qr.QrDataFactory;
+import dev.samstevens.totp.qr.QrGenerator;
+import dev.samstevens.totp.secret.SecretGenerator;
+
+/**
+ * Service which contains logic to set up MFA authentication
+ */
+public class MfaSetupServiceImpl implements MfaSetupService {
+
+    private final SecretGenerator secretGenerator;
+    private final QrDataFactory qrDataFactory;
+    private final QrGenerator qrGenerator;
+    private final String issuer;
+
+    public MfaSetupServiceImpl(SecretGenerator secretGenerator, QrDataFactory qrDataFactory, QrGenerator qrGenerator, String issuer) {
+        this.secretGenerator = secretGenerator;
+        this.qrDataFactory = qrDataFactory;
+        this.qrGenerator = qrGenerator;
+        this.issuer = issuer;
+    }
+
+    /**
+     * Generates a new MFA secret
+     * The secret is to be stored in a secure way for the given user.
+     * @return Secret key to generate a QR code and to validate MFA authentication codes.
+     */
+    public String generateSecret() {
+        // Generates a new MFA secret
+        return secretGenerator.generate();
+    }
+
+    /**
+     * Generates a new MFA QR code
+     * @param secret Secret key of the user
+     * @param label Label to show in the MFA app. This must be something related to the user (e.g. username, email address).
+     * @return A base64-encoded DATA URI of the QR code. This can for example be used in a HTML img element.
+     * @throws MfaException If the QR code cannot be generated.
+     */
+    public String generateQrCode(String secret, String label) throws MfaException {
+        QrData data = qrDataFactory.newBuilder()
+            .label(label)
+            .secret(secret)
+            .issuer(issuer)
+            .build();
+
+        // Generate the QR code image data as a base64 string which
+        // can be used in an <img> tag:
+        try {
+            return getDataUriForImage(
+                    qrGenerator.generate(data),
+                    qrGenerator.getImageMimeType()
+            );
+        } catch (QrGenerationException e) {
+            throw new MfaException("Unable to generate QR code", e);
+        }
+    }
+}

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaValidationService.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaValidationService.java
@@ -1,0 +1,6 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+public interface MfaValidationService {
+
+    boolean verifyMfaCode(String secret, String code);
+}

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaValidationServiceImpl.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaValidationServiceImpl.java
@@ -1,0 +1,25 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+import dev.samstevens.totp.code.CodeVerifier;
+
+/**
+ * Service which contains logic to validate MFA tokens.
+ */
+public class MfaValidationServiceImpl implements MfaValidationService {
+
+    private final CodeVerifier verifier;
+
+    public MfaValidationServiceImpl(CodeVerifier verifier) {
+        this.verifier = verifier;
+    }
+
+    /**
+     * Validates if the given MFA code is valid right now.
+     * @param secret Secret key of the user (e.g. from a database or credentials store)
+     * @param code Given MFA code (usually a 6-digit key)
+     * @return True if the given MFA code is valid. False if not.
+     */
+    public boolean verifyMfaCode(String secret, String code) {
+        return verifier.isValidCode(secret, code);
+    }
+}

--- a/src/main/java/nl/_42/restsecure/autoconfigure/errorhandling/DefaultLoginAuthenticationExceptionHandler.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/errorhandling/DefaultLoginAuthenticationExceptionHandler.java
@@ -8,7 +8,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import lombok.RequiredArgsConstructor;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaAuthenticationProvider;
 
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.AuthenticationException;
 
 @RequiredArgsConstructor
@@ -19,6 +21,11 @@ public class DefaultLoginAuthenticationExceptionHandler implements LoginAuthenti
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
-        errorHandler.respond(response, UNAUTHORIZED, SERVER_LOGIN_FAILED_ERROR);
+        // If the MFA code is needed but not provided, indicate this so the client can trigger the MFA login procedure.
+        if (exception instanceof InsufficientAuthenticationException && exception.getMessage().equals(MfaAuthenticationProvider.SERVER_MFA_CODE_REQUIRED_ERROR)) {
+            errorHandler.respond(response, UNAUTHORIZED, MfaAuthenticationProvider.SERVER_MFA_CODE_REQUIRED_ERROR);
+        } else {
+            errorHandler.respond(response, UNAUTHORIZED, SERVER_LOGIN_FAILED_ERROR);
+        }
     }
 }

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,3 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=nl._42.restsecure.autoconfigure.WebSecurityAutoConfig
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+nl._42.restsecure.autoconfigure.WebSecurityAutoConfig,\
+nl._42.restsecure.autoconfigure.MfaSecurityAutoConfig

--- a/src/test/java/nl/_42/restsecure/autoconfigure/AbstractApplicationContextTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/AbstractApplicationContextTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
+import dev.samstevens.totp.spring.autoconfigure.TotpAutoConfiguration;
 import nl._42.restsecure.autoconfigure.authentication.ArgumentResolverConfig;
 import nl._42.restsecure.autoconfigure.authentication.UserDetailsAdapter;
 
@@ -23,14 +24,14 @@ import org.springframework.web.context.support.AnnotationConfigWebApplicationCon
 public abstract class AbstractApplicationContextTest {
 
     protected AnnotationConfigWebApplicationContext context;
-    
+
     @AfterEach
     public void tearDown() {
         if (this.context != null) {
             this.context.close();
         }
     }
-    
+
     protected MockMvc getWebClient(Class<?>... appConfig) {
         loadApplicationContext(appConfig);
         return webAppContextSetup(context)
@@ -55,7 +56,10 @@ public abstract class AbstractApplicationContextTest {
                 JacksonAutoConfiguration.class,
                 HttpMessageConvertersAutoConfiguration.class,
                 WebSecurityAutoConfig.class,
-                ArgumentResolverConfig.class);
+                ArgumentResolverConfig.class,
+                TotpAutoConfiguration.class,
+                MfaSecurityAutoConfig.class);
+
         applicationContext.setServletContext(new MockServletContext());
         applicationContext.refresh();
         return applicationContext;

--- a/src/test/java/nl/_42/restsecure/autoconfigure/MfaSecurityAutoConfigTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/MfaSecurityAutoConfigTest.java
@@ -1,0 +1,51 @@
+package nl._42.restsecure.autoconfigure;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.samstevens.totp.code.CodeVerifier;
+import dev.samstevens.totp.code.DefaultCodeVerifier;
+import dev.samstevens.totp.qr.QrGenerator;
+import dev.samstevens.totp.qr.ZxingPngQrGenerator;
+import dev.samstevens.totp.secret.DefaultSecretGenerator;
+import dev.samstevens.totp.secret.SecretGenerator;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaAuthenticationProvider;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaSetupRequiredFilter;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaSetupService;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaSetupServiceImpl;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaValidationService;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaValidationServiceImpl;
+import nl._42.restsecure.autoconfigure.test.MfaAuthenticationConfig;
+import nl._42.restsecure.autoconfigure.test.MockMfaAuthenticationConfig;
+
+import org.junit.jupiter.api.Test;
+
+class MfaSecurityAutoConfigTest extends AbstractApplicationContextTest {
+
+
+    @Test
+    public void autoConfig_shouldConfigureMfaServices() {
+        loadApplicationContext(MfaAuthenticationConfig.class);
+        this.context.refresh();
+
+        MfaSetupService mfaSetupService = context.getBean(MfaSetupService.class);
+        assertEquals(MfaSetupServiceImpl.class, mfaSetupService.getClass());
+
+        MfaValidationService mfaValidationService = context.getBean(MfaValidationService.class);
+        assertEquals(MfaValidationServiceImpl.class, mfaValidationService.getClass());
+
+        MfaAuthenticationProvider mfaAuthenticationProvider = context.getBean(MfaAuthenticationProvider.class);
+        assertEquals(MfaAuthenticationProvider.class, mfaAuthenticationProvider.getClass());
+
+        MfaSetupRequiredFilter mfaSetupRequiredFilter = context.getBean(MfaSetupRequiredFilter.class);
+        assertEquals(MfaSetupRequiredFilter.class, mfaSetupRequiredFilter.getClass());
+
+        CodeVerifier codeVerifier = context.getBean(CodeVerifier.class);
+        assertEquals(DefaultCodeVerifier.class, codeVerifier.getClass());
+
+        SecretGenerator secretGenerator = context.getBean(SecretGenerator.class);
+        assertEquals(DefaultSecretGenerator.class, secretGenerator.getClass());
+
+        QrGenerator qrGenerator = context.getBean(QrGenerator.class);
+        assertEquals(ZxingPngQrGenerator.class, qrGenerator.getClass());
+    }
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/UserWithPassword.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/UserWithPassword.java
@@ -1,0 +1,20 @@
+package nl._42.restsecure.autoconfigure.authentication;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class UserWithPassword extends User {
+
+  private final String password;
+
+  public UserWithPassword(String username, String password, String role) {
+    super(username, role);
+    this.password = password;
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaAuthenticationProviderTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaAuthenticationProviderTest.java
@@ -1,0 +1,229 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.Objects;
+
+import nl._42.restsecure.autoconfigure.authentication.InMemoryUserDetailService;
+import nl._42.restsecure.autoconfigure.authentication.User;
+import nl._42.restsecure.autoconfigure.authentication.UserDetailsAdapter;
+import nl._42.restsecure.autoconfigure.authentication.UserWithPassword;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+
+class MfaAuthenticationProviderTest {
+
+    @Nested
+    class additionalAuthenticationChecks {
+
+        private MfaAuthenticationProvider provider;
+        private InMemoryUserDetailService inMemoryUserDetailService;
+        private final UserDetailsService noUserDetailsAdapterUserDetailsService = username -> {
+            if (Objects.equals(username, "username")) {
+                return new org.springframework.security.core.userdetails.User(username, "password", Collections.emptyList());
+            }
+            throw new UsernameNotFoundException("User was not found");
+        };
+        private MockMfaValidationService mockMfaValidationService;
+
+        @BeforeEach
+        void setup() {
+            inMemoryUserDetailService = new InMemoryUserDetailService();
+            mockMfaValidationService = new MockMfaValidationService();
+            provider = new MfaAuthenticationProvider();
+            provider.setUserDetailsService(inMemoryUserDetailService);
+            provider.setPasswordEncoder(NoOpPasswordEncoder.getInstance());
+            provider.setMfaValidationService(mockMfaValidationService);
+        }
+
+        @Nested
+        class afterPropertiesSet {
+
+            @Test
+            @DisplayName("should throw if userDetailsService or mfaValidationService have not been set")
+            void shouldThrowForMissingDependencies() {
+                MfaAuthenticationProvider provider = new MfaAuthenticationProvider();
+                IllegalArgumentException e = assertThrows(IllegalArgumentException.class, provider::doAfterPropertiesSet);
+                assertEquals("A UserDetailsService must be set", e.getMessage());
+
+                provider.setUserDetailsService(new InMemoryUserDetailService());
+                e = assertThrows(IllegalArgumentException.class, provider::doAfterPropertiesSet);
+                assertEquals("A MfaValidationService must be set", e.getMessage());
+
+                provider.setMfaValidationService(new MockMfaValidationService());
+                assertDoesNotThrow(provider::doAfterPropertiesSet);
+            }
+        }
+
+        @Nested
+        class mfaDisabledNonMandatory {
+
+            @Test
+            @DisplayName("should login with just username/password")
+            void shouldLoginWithUsernameAndPassword() {
+                User user = new UserWithPassword("username", "password", "Hoi");
+                inMemoryUserDetailService.register(user);
+
+                MfaAuthenticationToken token = new MfaAuthenticationToken("username", "password", null);
+                Authentication authentication = provider.authenticate(token);
+
+                assertTrue(authentication.isAuthenticated());
+                assertTrue(authentication instanceof UsernamePasswordAuthenticationToken);
+                UserDetailsAdapter<UserWithPassword> userDetailsAdapter = (UserDetailsAdapter<UserWithPassword>) authentication.getPrincipal();
+                assertEquals(user, userDetailsAdapter.getUser());
+                assertNull(authentication.getDetails());
+            }
+
+            @Test
+            @DisplayName("should throw bad credentials exception for invalid username or password")
+            void shouldThrowForBadCredentials() {
+                User user = new UserWithPassword("username", "password", "Hoi");
+                inMemoryUserDetailService.register(user);
+
+                MfaAuthenticationToken tokenUsernameWrong = new MfaAuthenticationToken("someone-else", "password", null);
+                MfaAuthenticationToken tokenPasswordWrong = new MfaAuthenticationToken("username", "wont-say-this", null);
+                BadCredentialsException e1 = assertThrows(BadCredentialsException.class, () -> provider.authenticate(tokenUsernameWrong));
+                BadCredentialsException e2 = assertThrows(BadCredentialsException.class, () -> provider.authenticate(tokenPasswordWrong));
+                assertEquals("Bad credentials", e1.getMessage());
+                assertEquals("Bad credentials", e2.getMessage());
+            }
+        }
+
+        @Nested
+        class mfaDisabledMandatory {
+            @Test
+            @DisplayName("should add 'mfa setup required' details for user without mfa whilst mfa is mandatory - no MFA code provided")
+            void shouldIndicateSetupRequiredWithoutMfaCode() {
+                User user = new UserWithMfa("username", "password", null, true, "Hoi");
+                inMemoryUserDetailService.register(user);
+
+                MfaAuthenticationToken token = new MfaAuthenticationToken("username", "password", null);
+                Authentication authentication = provider.authenticate(token);
+
+                assertTrue(authentication.isAuthenticated());
+                assertTrue(authentication instanceof UsernamePasswordAuthenticationToken);
+                UserDetailsAdapter<UserWithPassword> userDetailsAdapter = (UserDetailsAdapter<UserWithPassword>) authentication.getPrincipal();
+                assertEquals(user, userDetailsAdapter.getUser());
+                assertEquals(MfaAuthenticationProvider.DETAILS_MFA_SETUP_REQUIRED, authentication.getDetails());
+            }
+
+            @Test
+            @DisplayName("should add 'mfa setup required' details for user without mfa whilst mfa is mandatory - MFA code provided")
+            void shouldIndicateSetupRequiredWithMfaCode() {
+                User user = new UserWithMfa("username", "password", null, true, "Hoi");
+                inMemoryUserDetailService.register(user);
+
+                MfaAuthenticationToken token = new MfaAuthenticationToken("username", "password", "123456");
+                Authentication authentication = provider.authenticate(token);
+
+                assertTrue(authentication.isAuthenticated());
+                assertTrue(authentication instanceof UsernamePasswordAuthenticationToken);
+                UserDetailsAdapter<UserWithPassword> userDetailsAdapter = (UserDetailsAdapter<UserWithPassword>) authentication.getPrincipal();
+                assertEquals(user, userDetailsAdapter.getUser());
+                assertEquals(MfaAuthenticationProvider.DETAILS_MFA_SETUP_REQUIRED, authentication.getDetails());
+            }
+        }
+
+        @Nested
+        class mfaEnabled {
+
+            @Test
+            @DisplayName("should authenticate if the code is valid - mfa enabled & mandatory")
+            void shouldAuthenticateValidCode_mfaMandatory() {
+                User user = new UserWithMfa("username", "password", "secret-key", true, "Hoi");
+                inMemoryUserDetailService.register(user);
+                mockMfaValidationService.register("secret-key", "123456");
+
+                MfaAuthenticationToken token = new MfaAuthenticationToken("username", "password", "123456");
+                Authentication authentication = provider.authenticate(token);
+
+                assertTrue(authentication.isAuthenticated());
+                assertTrue(authentication instanceof UsernamePasswordAuthenticationToken);
+                UserDetailsAdapter<UserWithPassword> userDetailsAdapter = (UserDetailsAdapter<UserWithPassword>) authentication.getPrincipal();
+                assertEquals(user, userDetailsAdapter.getUser());
+                assertNull(authentication.getDetails());
+            }
+
+            @Test
+            @DisplayName("should authenticate if the code is valid - mfa enabled & not mandatory")
+            void shouldAuthenticateValidCode_mfaNotMandatory() {
+                User user = new UserWithMfa("username", "password", "secret-key", false, "Hoi");
+                inMemoryUserDetailService.register(user);
+                mockMfaValidationService.register("secret-key", "123456");
+
+                MfaAuthenticationToken token = new MfaAuthenticationToken("username", "password", "123456");
+                Authentication authentication = provider.authenticate(token);
+
+                assertTrue(authentication.isAuthenticated());
+                assertTrue(authentication instanceof UsernamePasswordAuthenticationToken);
+                UserDetailsAdapter<UserWithPassword> userDetailsAdapter = (UserDetailsAdapter<UserWithPassword>) authentication.getPrincipal();
+                assertEquals(user, userDetailsAdapter.getUser());
+                assertNull(authentication.getDetails());
+            }
+
+            @Test
+            @DisplayName("should throw BadCredentialsException if the code is invalid")
+            void shouldThrowIfCodeInvalid() {
+                User user = new UserWithMfa("username", "password", "secret-key", false, "Hoi");
+                inMemoryUserDetailService.register(user);
+                mockMfaValidationService.register("secret-key", "123456");
+
+                MfaAuthenticationToken token = new MfaAuthenticationToken("username", "password", "234567");
+                BadCredentialsException e = assertThrows(BadCredentialsException.class, () -> provider.authenticate(token));
+                assertEquals("SERVER.LOGIN_FAILED_ERROR", e.getMessage());
+            }
+
+            @Test
+            @DisplayName("should throw InsufficientAuthenticationException if the code is missing")
+            void shouldThrowIfCodeMissing() {
+                User user = new UserWithMfa("username", "password", "secret-key", false, "Hoi");
+                inMemoryUserDetailService.register(user);
+                mockMfaValidationService.register("secret-key", "123456");
+
+                MfaAuthenticationToken nullToken = new MfaAuthenticationToken("username", "password", null);
+                InsufficientAuthenticationException e = assertThrows(InsufficientAuthenticationException.class, () -> provider.authenticate(nullToken));
+                assertEquals("SERVER.MFA_CODE_REQUIRED_ERROR", e.getMessage());
+
+                MfaAuthenticationToken emptyStringToken = new MfaAuthenticationToken("username", "password", "");
+                InsufficientAuthenticationException e2 = assertThrows(InsufficientAuthenticationException.class, () -> provider.authenticate(emptyStringToken));
+                assertEquals("SERVER.MFA_CODE_REQUIRED_ERROR", e2.getMessage());
+            }
+        }
+
+        @Nested
+        class otherUserTypes {
+
+            @Test
+            @DisplayName("should not perform additional authentication checks if user is not of type UserDetailsAdapter")
+            void shouldDoNothingForOtherUsers() {
+                provider.setUserDetailsService(noUserDetailsAdapterUserDetailsService);
+
+                MfaAuthenticationToken token = new MfaAuthenticationToken("username", "password", "123456");
+                Authentication authentication = provider.authenticate(token);
+
+                assertTrue(authentication.isAuthenticated());
+                assertTrue(authentication instanceof UsernamePasswordAuthenticationToken);
+
+                MfaAuthenticationToken wrongToken = new MfaAuthenticationToken("username", "passwrod", "123456");
+                assertThrows(BadCredentialsException.class, () -> provider.authenticate(wrongToken));
+            }
+        }
+    }
+
+    @Test
+    void supports() {
+        assertTrue(new MfaAuthenticationProvider().supports(MfaAuthenticationToken.class));
+        assertFalse(new MfaAuthenticationProvider().supports(UsernamePasswordAuthenticationToken.class));
+    }
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaAuthenticationTokenTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaAuthenticationTokenTest.java
@@ -1,0 +1,14 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class MfaAuthenticationTokenTest {
+
+    @Test
+    void getVerificationCode() {
+        assertEquals("424242", new MfaAuthenticationToken("user", "secret", "424242").getVerificationCode());
+        assertEquals("242424", new MfaAuthenticationToken("user", "secret", "242424").getVerificationCode());
+    }
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaExceptionTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaExceptionTest.java
@@ -1,0 +1,18 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class MfaExceptionTest {
+
+    @Test
+    void returnsMessageAndCause() {
+        String message = "Oh no! Something went wrong!";
+        Exception cause = new RuntimeException("Should never happen");
+        MfaException exception = new MfaException(message, cause);
+        assertEquals(message, exception.getMessage());
+        assertEquals(cause, exception.getCause());
+    }
+
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaSetupRequiredFilterTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaSetupRequiredFilterTest.java
@@ -1,0 +1,105 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import nl._42.restsecure.autoconfigure.AbstractApplicationContextTest;
+import nl._42.restsecure.autoconfigure.authentication.InMemoryUserDetailService;
+import nl._42.restsecure.autoconfigure.test.MockMfaAuthenticationConfig;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class MfaSetupRequiredFilterTest extends AbstractApplicationContextTest {
+
+    private MfaSetupRequiredFilter filter;
+    private MockMvc webClient;
+
+    private final UsernamePasswordAuthenticationToken authenticationWithValidMfaConfiguration = new MfaAuthenticationToken("user1", "*****", "123456");
+    private final UsernamePasswordAuthenticationToken authenticationWithInvalidMfaConfiguration = new MfaAuthenticationToken("user2", "*****", "234567");
+    {
+        authenticationWithInvalidMfaConfiguration.setDetails(MfaAuthenticationProvider.DETAILS_MFA_SETUP_REQUIRED);
+    }
+
+    @BeforeEach
+    void setup() {
+        webClient = getWebClient(MockMfaAuthenticationConfig.class);
+        filter = context.getBean(MfaSetupRequiredFilter.class);
+        InMemoryUserDetailService userDetailService = (InMemoryUserDetailService) context.getBean(UserDetailsService.class);
+        userDetailService.register(new UserWithMfa("user1", "*****", "mfa-secret", true, "admin"));
+        userDetailService.register(new UserWithMfa("user2", "*****", null, true, "super-admin"));
+        MockMfaValidationService mfaValidationService = (MockMfaValidationService) context.getBean(MfaValidationService.class);
+        mfaValidationService.register("mfa-secret", "123456");
+    }
+
+    @Nested
+    class afterPropertiesSet {
+
+        @Test
+        @DisplayName("should throw if ObjectMapper has not been set")
+        void shouldThrowForMissingObjectMapper() {
+            MfaSetupRequiredFilter mockFilter = new MfaSetupRequiredFilter();
+            IllegalArgumentException e = assertThrows(IllegalArgumentException.class, mockFilter::afterPropertiesSet);
+            assertEquals("A ObjectMapper must be set", e.getMessage());
+
+            mockFilter.setObjectMapper(new ObjectMapper());
+            assertDoesNotThrow(mockFilter::afterPropertiesSet);
+        }
+    }
+
+    @Nested
+    class filter {
+        @Test
+        void shouldAllowRequest_whenExcludedByUrl() throws Exception {
+            filter.getExcludedRequests().add(new AntPathRequestMatcher("/users/**", HttpMethod.GET.name()));
+
+            webClient
+                    .perform(get("/users/me")
+                            .with(authentication(authenticationWithInvalidMfaConfiguration)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("username").value("user2"));
+        }
+
+        @Test
+        void shouldAllowRequest_whenExcludedByLogicCheck() throws Exception {
+            filter.getExclusionChecks().add((req, res) -> true);
+
+            webClient
+                    .perform(get("/users/me")
+                            .with(authentication(authenticationWithInvalidMfaConfiguration)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("username").value("user2"));
+        }
+
+        @Test
+        void shouldAllowRequest_withValidMfaConfiguration() throws Exception {
+            webClient
+                    .perform(get("/users/me")
+                            .with(authentication(authenticationWithValidMfaConfiguration)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("username").value("user1"));
+        }
+
+        @Test
+        void shouldDenyRequest_whenNotExcludedAndMfaConfigurationIsInvalid() throws Exception {
+            webClient
+                    .perform(get("/users/me")
+                            .with(authentication(authenticationWithInvalidMfaConfiguration)))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.errorCode").value("SERVER.MFA_SETUP_REQUIRED_ERROR"));
+        }
+    }
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaSetupServiceImplTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaSetupServiceImplTest.java
@@ -1,0 +1,98 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import dev.samstevens.totp.code.HashingAlgorithm;
+import dev.samstevens.totp.exceptions.QrGenerationException;
+import dev.samstevens.totp.qr.QrData;
+import dev.samstevens.totp.qr.QrDataFactory;
+import dev.samstevens.totp.qr.QrGenerator;
+import dev.samstevens.totp.qr.ZxingPngQrGenerator;
+import dev.samstevens.totp.secret.DefaultSecretGenerator;
+import dev.samstevens.totp.secret.SecretGenerator;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.StringUtils;
+
+class MfaSetupServiceImplTest {
+
+    @Nested
+    class generateSecret {
+
+        @Test
+        @DisplayName("should call SecretGenerator to generate a new secret")
+        void shouldCallSecretGeneratorToGenerateSecret() {
+            SecretGenerator mockSecretGenerator = new SecretGenerator() {
+                private final AtomicInteger index = new AtomicInteger(1);
+
+                @Override
+                public String generate() {
+                    return String.valueOf(index.getAndIncrement()).repeat(6);
+                }
+            };
+
+            MfaSetupServiceImpl setupService = new MfaSetupServiceImpl(mockSecretGenerator, null, null, "Rest-secure");
+            assertEquals("111111", setupService.generateSecret());
+            assertEquals("222222", setupService.generateSecret());
+        }
+
+        @Test
+        @DisplayName("should call secret generator to generate a hash")
+        void shouldCallRealSecretGEneratorToGenerateHash() {
+            MfaSetupServiceImpl setupService = new MfaSetupServiceImpl(new DefaultSecretGenerator(), new QrDataFactory(HashingAlgorithm.SHA1, 6, 1), new ZxingPngQrGenerator(), "Rest-secure");
+            String[] secrets = new String[10_000];
+
+            for (int i = 0; i < 10000; i++) {
+                secrets[i] = setupService.generateSecret();
+            }
+
+            Set<String> distinctSecrets = new HashSet<>(Arrays.asList(secrets));
+            assertEquals(10_000, distinctSecrets.size());
+            assertTrue(distinctSecrets.stream().noneMatch(secret -> secret == null || StringUtils.isBlank(secret)));
+        }
+    }
+
+    @Test
+    @DisplayName("Encodes generated qr code in base64")
+    void generateQrCode() throws MfaException {
+        MfaSetupServiceImpl setupService = new MfaSetupServiceImpl(new DefaultSecretGenerator(), new QrDataFactory(HashingAlgorithm.SHA1, 6, 1), new ZxingPngQrGenerator(), "Rest-secure");
+        String qr = setupService.generateQrCode(setupService.generateSecret(), "test-user");
+
+        assertTrue(qr.startsWith("data:image/png;base64,"));
+    }
+
+    @Test
+    @DisplayName("throws mfaException if a qrException is thrown")
+    void throwsMfaExceptionWhenCodeCannotBeGenerated() {
+        SecretGenerator secretGenerator = new DefaultSecretGenerator();
+        QrDataFactory qrDataFactory = new QrDataFactory(HashingAlgorithm.SHA1, 6, 1);
+        QrGenerator exceptionThrowingQrGenerator = new QrGenerator() {
+            @Override
+            public String getImageMimeType() {
+                return null;
+            }
+
+            @Override
+            public byte[] generate(QrData data) throws QrGenerationException {
+                throw new QrGenerationException("Not generating your code, today!", new RuntimeException("Test"));
+            }
+        };
+        String issuer = "Test issuer";
+
+        MfaSetupServiceImpl setupService = new MfaSetupServiceImpl(secretGenerator, qrDataFactory, exceptionThrowingQrGenerator, issuer);
+
+        MfaException exception = assertThrows(MfaException.class, () -> setupService.generateQrCode("very-secret", "something-special"));
+        assertEquals("Unable to generate QR code", exception.getMessage());
+        assertEquals(QrGenerationException.class, exception.getCause().getClass());
+        assertEquals("Not generating your code, today!", exception.getCause().getMessage());
+        assertEquals(RuntimeException.class, exception.getCause().getCause().getClass());
+        assertEquals("Test", exception.getCause().getCause().getMessage());
+    }
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaValidationServiceImplTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaValidationServiceImplTest.java
@@ -1,0 +1,25 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MfaValidationServiceImplTest {
+
+    @Nested
+    class verifyMfaCode {
+
+        @Test
+        @DisplayName("should call codeVerifier to verify the MFA code")
+        void shouldCallCodeVerifierToVerifyCode() {
+            MfaValidationServiceImpl validationService = new MfaValidationServiceImpl((secret, code) -> secret.equals("i-am-here") && code.equals("123456"));
+
+            assertTrue(validationService.verifyMfaCode("i-am-here", "123456"));
+            assertFalse(validationService.verifyMfaCode("i-am-here", "123457"));
+            assertFalse(validationService.verifyMfaCode("i-am-not-here", "123456"));
+        }
+    }
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MockMfaValidationService.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MockMfaValidationService.java
@@ -1,0 +1,21 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import nl._42.restsecure.autoconfigure.authentication.User;
+
+public class MockMfaValidationService implements MfaValidationService {
+
+    private Map<String, String> secretsAndCodes = new HashMap<>();
+
+    public void register(String secret, String allowedCode) {
+        secretsAndCodes.put(secret, allowedCode);
+    }
+
+    @Override
+    public boolean verifyMfaCode(String secret, String code) {
+        return code != null && Objects.equals(code, secretsAndCodes.get(secret));
+    }
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/UserWithMfa.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/UserWithMfa.java
@@ -1,0 +1,33 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+import nl._42.restsecure.autoconfigure.authentication.User;
+import nl._42.restsecure.autoconfigure.authentication.UserWithPassword;
+
+import org.junit.platform.commons.util.StringUtils;
+
+public class UserWithMfa extends UserWithPassword {
+
+  private final String secretKey;
+  private final boolean mandatory;
+
+  public UserWithMfa(String username, String password, String secretKey, boolean mandatory, String role) {
+    super(username, password, role);
+    this.secretKey = secretKey;
+    this.mandatory = mandatory;
+  }
+
+  @Override
+  public boolean isMfaConfigured() {
+    return StringUtils.isNotBlank(secretKey);
+  }
+
+  @Override
+  public boolean isMfaMandatory() {
+    return mandatory;
+  }
+
+  @Override
+  public String getMfaSecretKey() {
+    return secretKey;
+  }
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/errorhandling/DefaultLoginAuthenticationExceptionHandlerTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/errorhandling/DefaultLoginAuthenticationExceptionHandlerTest.java
@@ -1,0 +1,59 @@
+package nl._42.restsecure.autoconfigure.errorhandling;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaAuthenticationProvider;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class DefaultLoginAuthenticationExceptionHandlerTest {
+
+    @Nested
+    class handle {
+
+        @Test
+        @DisplayName("should return MFA_CODE_REQUIRED error for insufficient auth exception with mfa code required message")
+        void shouldReturnMfaCodeRequiredError() throws IOException {
+            DefaultLoginAuthenticationExceptionHandler handler = new DefaultLoginAuthenticationExceptionHandler(new GenericErrorHandler(new ObjectMapper()));
+
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            handler.handle(new MockHttpServletRequest(), response, new InsufficientAuthenticationException(MfaAuthenticationProvider.SERVER_MFA_CODE_REQUIRED_ERROR));
+
+            assertEquals(HttpStatus.UNAUTHORIZED.value(), response.getStatus());
+            assertEquals("{\"errorCode\":\"SERVER.MFA_CODE_REQUIRED_ERROR\"}", response.getContentAsString());
+        }
+
+        @Test
+        @DisplayName("should return SERVER_LOGIN_FAILED_ERROR error for any other exception")
+        void shouldReturnLoginFailedErrorForAnyOtherException() throws IOException {
+            DefaultLoginAuthenticationExceptionHandler handler = new DefaultLoginAuthenticationExceptionHandler(new GenericErrorHandler(new ObjectMapper()));
+
+            MockHttpServletResponse response1 = new MockHttpServletResponse();
+            MockHttpServletResponse response2 = new MockHttpServletResponse();
+            MockHttpServletResponse response3 = new MockHttpServletResponse();
+            // Case 1 is the MFA case, but with exception class of another type (thus should not be picked up)
+            handler.handle(new MockHttpServletRequest(), response1, new BadCredentialsException(MfaAuthenticationProvider.SERVER_MFA_CODE_REQUIRED_ERROR));
+            handler.handle(new MockHttpServletRequest(), response2, new BadCredentialsException(DefaultLoginAuthenticationExceptionHandler.SERVER_LOGIN_FAILED_ERROR));
+            handler.handle(new MockHttpServletRequest(), response3, new BadCredentialsException("Invalid username or password"));
+
+            assertEquals(HttpStatus.UNAUTHORIZED.value(), response1.getStatus());
+            assertEquals(HttpStatus.UNAUTHORIZED.value(), response2.getStatus());
+            assertEquals(HttpStatus.UNAUTHORIZED.value(), response3.getStatus());
+            assertEquals("{\"errorCode\":\"SERVER.LOGIN_FAILED_ERROR\"}", response1.getContentAsString());
+            assertEquals("{\"errorCode\":\"SERVER.LOGIN_FAILED_ERROR\"}", response2.getContentAsString());
+            assertEquals("{\"errorCode\":\"SERVER.LOGIN_FAILED_ERROR\"}", response3.getContentAsString());
+        }
+
+    }
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/test/ActiveUserAndMfaConfig.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/test/ActiveUserAndMfaConfig.java
@@ -1,0 +1,31 @@
+package nl._42.restsecure.autoconfigure.test;
+
+import static nl._42.restsecure.autoconfigure.test.AbstractUserDetailsServiceConfig.RegisteredUserBuilder.user;
+
+import nl._42.restsecure.autoconfigure.authentication.RegisteredUser;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaAuthenticationProvider;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaValidationService;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class ActiveUserAndMfaConfig extends AbstractUserDetailsServiceConfig {
+
+    @Override
+    protected RegisteredUser foundUser() {
+        return user().build();
+    }
+
+    @Bean
+    public MfaAuthenticationProvider mfaAuthenticationProvider(PasswordEncoder passwordEncoder, UserDetailsService userDetailsService, MfaValidationService mfaValidationService) {
+        MfaAuthenticationProvider authenticationProvider = new MfaAuthenticationProvider();
+        authenticationProvider.setMfaValidationService(mfaValidationService);
+        authenticationProvider.setUserDetailsService(userDetailsService);
+        authenticationProvider.setPasswordEncoder(passwordEncoder);
+        return authenticationProvider;
+    }
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/test/MfaAuthenticationConfig.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/test/MfaAuthenticationConfig.java
@@ -1,0 +1,47 @@
+package nl._42.restsecure.autoconfigure.test;
+
+import nl._42.restsecure.autoconfigure.HttpSecurityCustomizer;
+import nl._42.restsecure.autoconfigure.authentication.InMemoryUserDetailService;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaAuthenticationProvider;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaSetupRequiredFilter;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaValidationService;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MockMfaValidationService;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+public class MfaAuthenticationConfig {
+
+    @Bean
+    public HttpSecurityCustomizer httpSecurityCustomizer() {
+        return http -> http
+                .addFilterBefore(mfaSetupRequiredFilter(), AnonymousAuthenticationFilter.class);
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return new InMemoryUserDetailService();
+    }
+
+    @Bean
+    public MfaAuthenticationProvider mfaAuthenticationProvider(MfaValidationService mfaValidationService) {
+        MfaAuthenticationProvider authenticationProvider = new MfaAuthenticationProvider();
+        authenticationProvider.setMfaValidationService(mfaValidationService);
+        authenticationProvider.setUserDetailsService(userDetailsService());
+        authenticationProvider.setPasswordEncoder(NoOpPasswordEncoder.getInstance());
+        return authenticationProvider;
+    }
+
+    @Bean
+    public MfaSetupRequiredFilter mfaSetupRequiredFilter() {
+        MfaSetupRequiredFilter filter = new MfaSetupRequiredFilter();
+        filter.setObjectMapper(new ObjectMapper());
+        return filter;
+    }
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/test/MockMfaAuthenticationConfig.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/test/MockMfaAuthenticationConfig.java
@@ -1,0 +1,52 @@
+package nl._42.restsecure.autoconfigure.test;
+
+import nl._42.restsecure.autoconfigure.HttpSecurityCustomizer;
+import nl._42.restsecure.autoconfigure.authentication.InMemoryUserDetailService;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaAuthenticationProvider;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaSetupRequiredFilter;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaValidationService;
+import nl._42.restsecure.autoconfigure.authentication.mfa.MockMfaValidationService;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+public class MockMfaAuthenticationConfig {
+
+    @Bean
+    public HttpSecurityCustomizer httpSecurityCustomizer() {
+        return http -> http
+                .addFilterBefore(mfaSetupRequiredFilter(), AnonymousAuthenticationFilter.class);
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return new InMemoryUserDetailService();
+    }
+
+    @Bean
+    public MfaValidationService mfaValidationService() {
+        return new MockMfaValidationService();
+    }
+
+    @Bean
+    public MfaAuthenticationProvider mfaAuthenticationProvider() {
+        MfaAuthenticationProvider authenticationProvider = new MfaAuthenticationProvider();
+        authenticationProvider.setMfaValidationService(mfaValidationService());
+        authenticationProvider.setUserDetailsService(userDetailsService());
+        authenticationProvider.setPasswordEncoder(NoOpPasswordEncoder.getInstance());
+        return authenticationProvider;
+    }
+
+    @Bean
+    public MfaSetupRequiredFilter mfaSetupRequiredFilter() {
+        MfaSetupRequiredFilter filter = new MfaSetupRequiredFilter();
+        filter.setObjectMapper(new ObjectMapper());
+        return filter;
+    }
+}


### PR DESCRIPTION
Extended rest-secure-spring-boot-starter to include support for
time-based two factor authentication (TOTP) using
`dev.samstevens.totp:totp-spring-boot-starter`.

Added a new `AuthenticationProvider` which performs validation on MFA
tokens. It supports the following features
- Checks if MFA is set-up
- Checks if MFA is mandatory for this user (e.g. based on user roles)
- Verifies the MFA code

Added a new `MfaSetupRequiredFilter` which can block HTTP requests if
the user is mandatory to use two-factor-authentication, but has not yet
set it up. This is done by checking the `Details` of the given
`Authentication`. The filter supports exclusion by URL and by logic
checks, to create certain paths of execution without valid 2FA (e.g. to
load resources needed to set up 2FA).