### PR TITLE
fix(mfa): Issuer must be present in label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [9.0.1] - 2021-11-18
+- Fixed: #20 The label of the 2FA QR code should get the issuer added as well to work properly with all authenticator apps.
+
 ## [9.0.0] - 2021-11-17
 - Added: Support for two-factor authentication (2FA, MFA)
 - Upgrade: From spring-boot 2.4 to 2.5

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaSetupServiceImpl.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaSetupServiceImpl.java
@@ -43,8 +43,20 @@ public class MfaSetupServiceImpl implements MfaSetupService {
      * @throws MfaException If the QR code cannot be generated.
      */
     public String generateQrCode(String secret, String label) throws MfaException {
+        if (label == null || label.equals("")) {
+            throw new MfaException("Label cannot be blank!", null);
+        }
+
+        String labelWithIssuer;
+
+        if (label.contains(issuer + ":")) {
+            labelWithIssuer = label;
+        } else {
+            labelWithIssuer = String.format("%s:%s", issuer, label);
+        }
+
         QrData data = qrDataFactory.newBuilder()
-            .label(label)
+            .label(labelWithIssuer)
             .secret(secret)
             .issuer(issuer)
             .build();

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaSetupServiceImplTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaSetupServiceImplTest.java
@@ -46,7 +46,7 @@ class MfaSetupServiceImplTest {
         @Test
         @DisplayName("should call secret generator to generate a hash")
         void shouldCallRealSecretGEneratorToGenerateHash() {
-            MfaSetupServiceImpl setupService = new MfaSetupServiceImpl(new DefaultSecretGenerator(), new QrDataFactory(HashingAlgorithm.SHA1, 6, 1), new ZxingPngQrGenerator(), "Rest-secure");
+            MfaSetupServiceImpl setupService = new MfaSetupServiceImpl(new DefaultSecretGenerator(), new QrDataFactory(HashingAlgorithm.SHA1, 6, 30), new ZxingPngQrGenerator(), "Rest-secure");
             String[] secrets = new String[10_000];
 
             for (int i = 0; i < 10000; i++) {
@@ -59,13 +59,88 @@ class MfaSetupServiceImplTest {
         }
     }
 
-    @Test
-    @DisplayName("Encodes generated qr code in base64")
-    void generateQrCode() throws MfaException {
-        MfaSetupServiceImpl setupService = new MfaSetupServiceImpl(new DefaultSecretGenerator(), new QrDataFactory(HashingAlgorithm.SHA1, 6, 1), new ZxingPngQrGenerator(), "Rest-secure");
-        String qr = setupService.generateQrCode(setupService.generateSecret(), "test-user");
+    @Nested
+    class generateQrCode {
+        @Test
+        @DisplayName("Encodes generated qr code in base64")
+        void generatesQrCode() throws MfaException {
+            MfaSetupServiceImpl setupService = new MfaSetupServiceImpl(new DefaultSecretGenerator(), new QrDataFactory(HashingAlgorithm.SHA1, 6, 30), new ZxingPngQrGenerator(), "Rest-secure");
+            String qr = setupService.generateQrCode(setupService.generateSecret(), "test-user");
 
-        assertTrue(qr.startsWith("data:image/png;base64,"));
+            assertTrue(qr.startsWith("data:image/png;base64,"));
+        }
+
+        @Test
+        @DisplayName("Calls qrGenerator with the right arguments (label, issuer, etc.")
+        void usesCorrectMetadata() throws MfaException {
+            final QrData[] qrDataHolder = new QrData[1];
+
+            String exampleSecret = "XK6PZWX6RK46LBGRXSYRN7RE2X56UQD7";
+            SecretGenerator mockSecretGenerator = () -> exampleSecret;
+
+            ZxingPngQrGenerator zxingPngQrGenerator = new ZxingPngQrGenerator();
+            QrGenerator mockQrGenerator = new QrGenerator() {
+                @Override
+                public String getImageMimeType() {
+                    return "image/png";
+                }
+
+                @Override
+                public byte[] generate(QrData data) throws QrGenerationException {
+                    qrDataHolder[0] = data;
+                    return zxingPngQrGenerator.generate(data);
+                }
+            };
+
+            String issuer = "Rest-secure Test Issuer";
+
+            MfaSetupServiceImpl setupService = new MfaSetupServiceImpl(mockSecretGenerator, new QrDataFactory(HashingAlgorithm.SHA1, 6, 30), mockQrGenerator, issuer);
+
+            String labelWithoutIssuer = "fake-issuer:test-user@example.com";
+            String qr = setupService.generateQrCode(setupService.generateSecret(), labelWithoutIssuer);
+            assertTrue(qr.startsWith("data:image/png;base64,"));
+
+            QrData generatedQrData = qrDataHolder[0];
+
+            assertNotNull(generatedQrData);
+            assertEquals(issuer, generatedQrData.getIssuer());
+            assertEquals("Rest-secure Test Issuer:fake-issuer:test-user@example.com", generatedQrData.getLabel());
+            assertEquals(exampleSecret, generatedQrData.getSecret());
+            assertEquals("totp", generatedQrData.getType());
+            assertEquals("SHA1", generatedQrData.getAlgorithm());
+            assertEquals(30, generatedQrData.getPeriod());
+            assertEquals(6, generatedQrData.getDigits());
+            assertEquals("otpauth://totp/Rest-secure%20Test%20Issuer%3Afake-issuer%3Atest-user%40example.com?secret=XK6PZWX6RK46LBGRXSYRN7RE2X56UQD7&issuer=Rest-secure%20Test%20Issuer&algorithm=SHA1&digits=6&period=30", generatedQrData.getUri());
+
+            // Generate a QR with the issuer already in the label, this should not add the issuer again.
+            String labelWithIssuer = "Rest-secure Test Issuer:test-user@example.com";
+            setupService.generateQrCode(setupService.generateSecret(), labelWithIssuer);
+            generatedQrData = qrDataHolder[0];
+
+            assertNotNull(generatedQrData);
+            assertEquals(issuer, generatedQrData.getIssuer());
+            assertEquals(labelWithIssuer, generatedQrData.getLabel());
+            assertEquals(exampleSecret, generatedQrData.getSecret());
+            assertEquals("totp", generatedQrData.getType());
+            assertEquals("SHA1", generatedQrData.getAlgorithm());
+            assertEquals(30, generatedQrData.getPeriod());
+            assertEquals(6, generatedQrData.getDigits());
+            assertEquals("otpauth://totp/Rest-secure%20Test%20Issuer%3Atest-user%40example.com?secret=XK6PZWX6RK46LBGRXSYRN7RE2X56UQD7&issuer=Rest-secure%20Test%20Issuer&algorithm=SHA1&digits=6&period=30", generatedQrData.getUri());
+
+        }
+
+        @Test
+        @DisplayName("throws if label is null or empty")
+        void throwsForMissingLabel() {
+            MfaSetupServiceImpl setupService = new MfaSetupServiceImpl(new DefaultSecretGenerator(), new QrDataFactory(HashingAlgorithm.SHA1, 6, 30), new ZxingPngQrGenerator(), "Rest-secure");
+            MfaException e1 = assertThrows(MfaException.class, () -> setupService.generateQrCode(setupService.generateSecret(), null));
+            MfaException e2 = assertThrows(MfaException.class, () -> setupService.generateQrCode(setupService.generateSecret(), ""));
+
+            assertEquals("Label cannot be blank!", e1.getMessage());
+            assertEquals("Label cannot be blank!", e2.getMessage());
+            assertNull(e1.getCause());
+            assertNull(e2.getCause());
+        }
     }
 
     @Test


### PR DESCRIPTION
Added issuer (followed by ":") to the label of a generated MFA QR code.
This makes the issuer appear in all popular authenticator apps (Google,
Microsoft and FreeOTP). Previously, it only showed up in Google since
they didn't follow the standards exactly...

Fixes #20