### PR TITLE
Made RequestAuthorizationCustomizer's customise method throw Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Now throwing an Exception in the RequestAuthorizationCustomizer's customize method so that
+  you don't have to wrap exceptions in RuntimeExceptions if they are thrown in the implementing
+  methods.
+
+## [10.0.1] - 2021-12-20
 - Added: additional constructor with customisable request matcher and ObjectMapper.
 
 ## [10.0.0] - 2021-12-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Upgrade: from spring-boot 2.5 to 2.6
 - Now throwing an Exception in the RequestAuthorizationCustomizer's customize method so that
   you don't have to wrap exceptions in RuntimeExceptions if they are thrown in the implementing
   methods.

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <spring-boot.version>2.5.7</spring-boot.version>
+        <spring-boot.version>2.6.2</spring-boot.version>
         <totp-spring-boot-starter.version>1.7.1</totp-spring-boot-starter.version>
 
         <dependency-check-maven-plugin.version>6.5.0</dependency-check-maven-plugin.version>
@@ -122,16 +122,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Whilst Spring Boot does not use Log4j by default (uses Logback instead), it still contains the log4j-api which is reported by OWASP as being vulnerable to Log4Shell (CVE-2021-44228). -->
-            <!-- By upgrading log4j2.version to 2.16.0, the log4j-api gets patched and we ensure that applications using this project will not be using an outdated version of log4j. -->
-            <!-- This dependency override can likely be removed after Spring Boot updates to 2.6.2 / 2.5.8 (due Dec. 23, 2021. See https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot) -->
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-bom</artifactId>
-                <version>2.16.0</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/src/main/java/nl/_42/restsecure/autoconfigure/RequestAuthorizationCustomizer.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/RequestAuthorizationCustomizer.java
@@ -11,5 +11,5 @@ import org.springframework.security.config.annotation.web.configurers.Expression
  */
 public interface RequestAuthorizationCustomizer {
 
-    ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry customize(ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry urlRegistry);
+    ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry customize(ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry urlRegistry) throws Exception;
 }

--- a/src/main/java/nl/_42/restsecure/autoconfigure/WebSecurityAutoConfig.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/WebSecurityAutoConfig.java
@@ -235,7 +235,7 @@ public class WebSecurityAutoConfig extends WebSecurityConfigurerAdapter {
     }
 
     private ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry customize(
-            ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry urlRegistry) {
+            ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry urlRegistry) throws Exception {
         if (authCustomizer != null) {
             log.info("Found RequestAuthorization bean in ApplicationContext, custom configuring of urlRegistry object started.");
             return authCustomizer.customize(urlRegistry);


### PR DESCRIPTION
In this way, you can let implementing classes throw exceptions too
rather than wrapping them in a RuntimeException and rethrowing
them.

As an implementor you don't really notice this otherwise since
we're not calling the method.