### PR TITLE
@CurrentUser can now be made optional

### DIFF
--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/CurrentUser.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/CurrentUser.java
@@ -9,8 +9,15 @@ import java.lang.annotation.Target;
  * Use this annotation on a controller method parameter to resolve the current logged in user.
  * Type of this parameter must be your custom user type implementing {@link RegisteredUser}.
  */
-@Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
 public @interface CurrentUser {
+
+    /**
+     * Is the current user required, or can the user also be {@code null}.
+     * When required, the resolver will throw an exception if no user is found.
+     * @return is required
+     */
+    boolean required() default true;
 
 }

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/CurrentUserArgumentResolverTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/CurrentUserArgumentResolverTest.java
@@ -1,28 +1,43 @@
 package nl._42.restsecure.autoconfigure.authentication;
 
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+
+import java.lang.reflect.Method;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.springframework.core.MethodParameter;
 
 class CurrentUserArgumentResolverTest {
 
     private final CurrentUserArgumentResolver resolver = new CurrentUserArgumentResolver(null);
 
     @Test
-    void supports_true() {
-        MethodParameter parameter = Mockito.mock(MethodParameter.class);
-        CurrentUser annotation = Mockito.mock(CurrentUser.class);
-        Mockito.when(parameter.getParameterAnnotation(CurrentUser.class)).thenReturn(annotation);
+    void supports_true() throws NoSuchMethodException {
+        Method method = MyController.class.getMethod("annotated", RegisteredUser.class);
+        MethodParameter parameter = new MethodParameter(method, 0);
 
         assertTrue(resolver.supportsParameter(parameter));
     }
 
     @Test
-    void supports_false() {
-        MethodParameter parameter = Mockito.mock(MethodParameter.class);
+    void supports_false() throws NoSuchMethodException {
+        Method method = MyController.class.getMethod("none", RegisteredUser.class);
+        MethodParameter parameter = new MethodParameter(method, 0);
+
         assertFalse(resolver.supportsParameter(parameter));
     }
+
+    public static class MyController {
+
+        public RegisteredUser annotated(@CurrentUser RegisteredUser user) {
+            return user;
+        }
+
+        public RegisteredUser none(RegisteredUser user) {
+            return user;
+        }
+
+    }
+
 }

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/GlobalExceptionHandler.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package nl._42.restsecure.autoconfigure.authentication;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RuntimeException.class)
+    public Map<String, String> handleRuntimeException(RuntimeException exception, HttpServletResponse response) {
+        response.setStatus(INTERNAL_SERVER_ERROR.value());
+        return error(exception);
+    }
+
+    private static Map<String, String> error(Throwable throwable) {
+        return Map.of("error", throwable.getMessage());
+    }
+
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/OptionalUser.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/OptionalUser.java
@@ -1,0 +1,13 @@
+package nl._42.restsecure.autoconfigure.authentication;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@CurrentUser(required = false)
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OptionalUser {
+
+}

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/UserController.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/UserController.java
@@ -12,4 +12,15 @@ public class UserController {
     public RegisteredUser me(@CurrentUser RegisteredUser user) {
         return user;
     }
+
+    @GetMapping("/optional")
+    public RegisteredUser optional(@CurrentUser(required = false) RegisteredUser user) {
+        return user;
+    }
+
+    @GetMapping("/custom")
+    public RegisteredUser custom(@OptionalUser RegisteredUser user) {
+        return user;
+    }
+
 }

--- a/src/test/java/nl/_42/restsecure/autoconfigure/authentication/UserControllerTest.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/authentication/UserControllerTest.java
@@ -1,15 +1,22 @@
 package nl._42.restsecure.autoconfigure.authentication;
 
+import nl._42.restsecure.autoconfigure.AbstractApplicationContextTest;
+import nl._42.restsecure.autoconfigure.test.ActiveUserConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Set;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import nl._42.restsecure.autoconfigure.AbstractApplicationContextTest;
-import nl._42.restsecure.autoconfigure.test.ActiveUserConfig;
-
-import org.junit.jupiter.api.Test;
-
 public class UserControllerTest extends AbstractApplicationContextTest {
+
+    private static final Authentication NONE = new AnonymousAuthenticationToken("key", "none", Set.of(new SimpleGrantedAuthority("ROLE_NONE")));
 
     @Test
     public void me_shouldSucceed_whenLoggedIn() throws Exception {
@@ -19,4 +26,35 @@ public class UserControllerTest extends AbstractApplicationContextTest {
                 .andExpect(jsonPath("authorities[0]").value("ROLE_ADMIN"))
                 .andExpect(jsonPath("username").value("username"));
     }
+
+    @Test
+    public void me_shouldError_whenNotLoggedIn() throws Exception {
+        getWebClient(ActiveUserConfig.class)
+            .perform(get("/users/me")
+                .with(authentication(NONE)))
+            .andExpect(status().is5xxServerError())
+            .andExpect(jsonPath("authorities").doesNotExist())
+            .andExpect(jsonPath("username").doesNotExist());
+    }
+
+    @Test
+    public void optional_shouldSucceed_whenNotLoggedIn() throws Exception {
+        getWebClient(ActiveUserConfig.class)
+            .perform(get("/users/optional")
+                .with(authentication(NONE)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("authorities").doesNotExist())
+            .andExpect(jsonPath("username").doesNotExist());
+    }
+
+    @Test
+    public void custom_shouldSucceed_whenNotLoggedIn() throws Exception {
+        getWebClient(ActiveUserConfig.class)
+            .perform(get("/users/custom")
+                .with(authentication(NONE)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("authorities").doesNotExist())
+            .andExpect(jsonPath("username").doesNotExist());
+    }
+
 }

--- a/src/test/java/nl/_42/restsecure/autoconfigure/test/AbstractUserDetailsServiceConfig.java
+++ b/src/test/java/nl/_42/restsecure/autoconfigure/test/AbstractUserDetailsServiceConfig.java
@@ -3,6 +3,7 @@ package nl._42.restsecure.autoconfigure.test;
 import java.util.Collections;
 import java.util.Set;
 
+import nl._42.restsecure.autoconfigure.RequestAuthorizationCustomizer;
 import nl._42.restsecure.autoconfigure.authentication.AbstractUserDetailsService;
 import nl._42.restsecure.autoconfigure.authentication.RegisteredUser;
 
@@ -18,6 +19,11 @@ public abstract class AbstractUserDetailsServiceConfig {
                 return foundUser();
             }
         };
+    }
+
+    @Bean
+    public RequestAuthorizationCustomizer requestAuthorizationCustomizer() {
+        return registry -> registry.antMatchers("/users/**").permitAll();
     }
 
     protected abstract RegisteredUser foundUser();
@@ -84,5 +90,7 @@ public abstract class AbstractUserDetailsServiceConfig {
                 }
             };
         }
+
     }
+
 }


### PR DESCRIPTION
The @CurrentUser annotation can now also be used in situations where the person is optional:

```
    @GetMapping("/current")
    public RegisteredUser current(@CurrentUser(required = false) RegisteredUser user) {
        return user;
    }
```

By default the current user is still required.