### PR TITLE
Fix #37: SERVER_MFA_CODE_REQUIRED_ERROR logged at DEBUG-level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Fixed #37: No longer logging SERVER_MFA_CODE_REQUIRED_ERROR at WARN-level by default, lowering cognitive load in logs. 
+
 ## [12.3.0] - 2023-12-07
 - Upgrade to Spring Boot 3.2.0
 - Made the AuthenticationManager in the WebSecurityAutoConfig conditional.

--- a/src/main/java/nl/_42/restsecure/autoconfigure/errorhandling/LogUtil.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/errorhandling/LogUtil.java
@@ -1,5 +1,7 @@
 package nl._42.restsecure.autoconfigure.errorhandling;
 
+import static nl._42.restsecure.autoconfigure.authentication.mfa.MfaAuthenticationProvider.SERVER_MFA_CODE_REQUIRED_ERROR;
+
 import nl._42.restsecure.autoconfigure.form.LoginForm;
 
 import org.slf4j.Logger;
@@ -9,7 +11,7 @@ public class LogUtil {
     private LogUtil() {}
 
     public static <T extends LoginForm> void logAuthenticationFailure(Logger log, T form, RuntimeException exception) {
-        if (log.isDebugEnabled()) {
+        if (log.isDebugEnabled() || exception.getMessage().equals(SERVER_MFA_CODE_REQUIRED_ERROR)) {
             log.debug("Authentication failure for user '{}'! {}", form.username, exception.getMessage(), exception);
         } else {
             log.warn("Authentication failure for user '{}'! {}", form.username, exception.getMessage());


### PR DESCRIPTION
Lowered cognitive load in application logs, by logging SERVER_MFA_CODE_REQUIRED_ERROR at DEBUG-level.

Closes #37