### PR TITLE
FIX: Removed unnecessary warn logs that are part of the login flow

### DIFF
--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaAuthenticationProvider.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaAuthenticationProvider.java
@@ -6,7 +6,6 @@ import java.util.List;
 import nl._42.restsecure.autoconfigure.authentication.RegisteredUser;
 import nl._42.restsecure.autoconfigure.authentication.UserDetailsAdapter;
 
-import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.core.AuthenticationException;
@@ -65,7 +64,7 @@ public class MfaAuthenticationProvider extends DaoAuthenticationProvider {
     private void executeMfaVerificationSteps(MfaAuthenticationToken mfaAuthenticationToken, UserDetailsAdapter<? extends RegisteredUser> userDetailsAdapter) {
         // If no code supplied, indicate a code is needed.
         if (mfaAuthenticationToken.getVerificationCode() == null || mfaAuthenticationToken.getVerificationCode().isEmpty()) {
-            throw new InsufficientAuthenticationException(SERVER_MFA_CODE_REQUIRED_ERROR);
+            throw new MfaRequiredException(SERVER_MFA_CODE_REQUIRED_ERROR);
         }
         boolean verificationSucceeded = false;
         for (MfaVerificationCheck verificationCheck : verificationChecks) {

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaRequiredException.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaRequiredException.java
@@ -1,14 +1,8 @@
 package nl._42.restsecure.autoconfigure.authentication.mfa;
 
-import org.springframework.security.authentication.InsufficientAuthenticationException;
-
-public class MfaRequiredException extends InsufficientAuthenticationException {
+public class MfaRequiredException extends RuntimeException {
 
     public MfaRequiredException(String msg) {
         super(msg);
-    }
-
-    public MfaRequiredException(String msg, Throwable cause) {
-        super(msg, cause);
     }
 }

--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaRequiredException.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/mfa/MfaRequiredException.java
@@ -1,0 +1,14 @@
+package nl._42.restsecure.autoconfigure.authentication.mfa;
+
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+
+public class MfaRequiredException extends InsufficientAuthenticationException {
+
+    public MfaRequiredException(String msg) {
+        super(msg);
+    }
+
+    public MfaRequiredException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/main/java/nl/_42/restsecure/autoconfigure/errorhandling/LogUtil.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/errorhandling/LogUtil.java
@@ -1,5 +1,6 @@
 package nl._42.restsecure.autoconfigure.errorhandling;
 
+import nl._42.restsecure.autoconfigure.authentication.mfa.MfaRequiredException;
 import nl._42.restsecure.autoconfigure.form.LoginForm;
 
 import org.slf4j.Logger;
@@ -9,10 +10,11 @@ public class LogUtil {
     private LogUtil() {}
 
     public static <T extends LoginForm> void logAuthenticationFailure(Logger log, T form, RuntimeException exception) {
-        if (log.isDebugEnabled()) {
+        // Filter out logs that are part of the login flow
+        if (log.isDebugEnabled() || exception instanceof MfaRequiredException || form.username == null) {
             log.debug("Authentication failure for user '{}'! {}", form.username, exception.getMessage(), exception);
-        } else {
-            log.warn("Authentication failure for user '{}'! {}", form.username, exception.getMessage());
+            return;
         }
+        log.warn("Authentication failure for user '{}'! {}", form.username, exception.getMessage());
     }
 }


### PR DESCRIPTION
Removed unnecessary WARN logs that have to do with the login flow.

Added 2 checks to the LogUtil:
* username is null
* exception == MfaRequiredException

When this is the case we want to debug it, not log a warning, since they are a normal part of the log in flow