### PR TITLE
Add getUserId to RegisteredUser

### DIFF
--- a/src/main/java/nl/_42/restsecure/autoconfigure/authentication/RegisteredUser.java
+++ b/src/main/java/nl/_42/restsecure/autoconfigure/authentication/RegisteredUser.java
@@ -10,6 +10,11 @@ import org.springframework.security.core.Authentication;
  */
 public interface RegisteredUser {
 
+    /**
+     * Can be useful when implementing own security checks
+     */
+    default String getUserId() {return null;}
+
     String getUsername();
 
     default String getPassword() {


### PR DESCRIPTION
This is needed by some projects in order to implement their own 2fa checks more consistently.

When using email 2fa, there is no secret key, instead a userId is used to retrieve the code.