### PR TITLE
Add GitHub Actions workflow for publishing to Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Publish package to the Maven Central Repository
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-version:
+        required: false
+        description: Release-version (not required)
+      next-version:
+        required: false
+        description: Next development-version. (not required)
+      java-version:
+        required: true
+        default: '21'
+        description: Java-version to use for the deployment.
+
+jobs:
+  call-workflow:
+    uses: 42BV/42-github-workflows/.github/workflows/maven-release.yml@master
+    secrets: inherit
+    with:
+      release-version: ${{ github.event.inputs.release-version }}
+      next-version: ${{ github.event.inputs.next-version }}
+      java-version: ${{ github.event.inputs.java-version }}


### PR DESCRIPTION
* Adds the release-action, which can be manually started to publish a new version to Maven Central.